### PR TITLE
Upload refactor metadata

### DIFF
--- a/src/Components/Upload/ExtraInfo.js
+++ b/src/Components/Upload/ExtraInfo.js
@@ -7,8 +7,8 @@ import PropTypes from 'prop-types'
 const ExtraInfo = ({ onSubmit, extraInfoFields, loading = false }) => {
   const steps = Object.entries(extraInfoFields).map(([type, fields]) => ({
     title: type,
-    fields: fields.map((field) => ({
-      name: field,
+    fields: fields.map((field, i) => ({
+      name: `${type}-${i}`,
       label: field,
       showLabel: true,
       rules: [{ required: true }],

--- a/src/Components/Upload/index.js
+++ b/src/Components/Upload/index.js
@@ -18,7 +18,7 @@ const Upload = () => {
   const history = useHistory()
 
   const onSubmit = async (data) => {
-    window.data = data;
+    window.data = data
     const { name, machine, description, temperature, study } = data
     setLoading(true)
 
@@ -35,23 +35,23 @@ const Upload = () => {
     fr.addEventListener('loadend', () => {
       apiWebSocket.connect('registry/upload', {
         onConnect(event, socket) {
-          console.log("onConnect")
+          console.log('onConnect')
           setConnectionSocket(socket)
           socket.send(JSON.stringify({ type: 'init_upload', data: form }))
         },
         onReceiveHandlers: {
           ready_for_file(msg, e, socket) {
-            console.log("ready_for_file")
+            console.log('ready_for_file')
             socket.send(fr.result)
           },
           input_requests(msg) {
-            console.log("input_requests")
+            console.log('input_requests')
             console.log(msg.data)
             setExtraDataFields(msg.data)
             setExtraDataVisible(true)
           },
           creation_done() {
-            console.log("creation_done")
+            console.log('creation_done')
             setLoading(false)
             message.success('Data uploaded successfully!')
             history.push('browse')
@@ -70,13 +70,16 @@ const Upload = () => {
 
   const onSubmitExtraInfo = (data) => {
     setExtraDataLoading(true)
-    const dataToSend = Object.entries(data).reduce(
-      (acc, [key, { value }]) => ({
-        ...acc,
-        [key]: value,
-      }),
-      {},
-    )
+    const dataToSend = Object.entries(data).reduce((acc, [key, { value }]) => {
+      const reg = key.match(/^(\w+)-\d+$/)[1]
+      if (!acc[reg]) {
+        acc[reg] = []
+      }
+
+      acc[reg].push(value)
+      return acc
+    }, {})
+
     console.log(dataToSend)
     connectionSocket.send(JSON.stringify({ type: 'metadata', data: dataToSend }))
     setExtraDataLoading(false)

--- a/src/Components/Upload/uploadForm.js
+++ b/src/Components/Upload/uploadForm.js
@@ -3,7 +3,7 @@ import { FileAddOutlined, ExperimentOutlined } from '@ant-design/icons'
 import { Typography } from 'antd'
 import SelectOrCreate from '../Forms/SelectOrCreate'
 import TextArea from '../Forms/TextArea'
-import RadioGroup from 'antd/lib/radio/group'
+import RadioGroup from '../Forms/RadioGroup'
 import FileInput from '../Forms/FileInput'
 
 const uploadSteps = [


### PR DESCRIPTION
- Fixed bug where Machine Radio Group was not `Form.Item`, so it wouldn't be sent to the backend.
- Formatted metadata before sending, so that it matches the following structure:
```py
{
    "dna": [1, 5, ...], # Values are in same order as received from backend
    "inducer": [3, 2, ...],
    ...
}
```