### PR TITLE
Fix/doi not required

### DIFF
--- a/src/Components/Browse/Studies.js
+++ b/src/Components/Browse/Studies.js
@@ -53,7 +53,10 @@ const Studies = () => {
       },
       delete: {
         label: 'Delete',
-        onClick: () => api.delete(`study/${record.id}/`),
+        onClick: () => {
+          api.delete(`study/${record.id}/`)
+          window.location.reload()
+        },
       },
     }
 

--- a/src/Components/Forms/Checkbox.js
+++ b/src/Components/Forms/Checkbox.js
@@ -2,9 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Form, Checkbox } from 'antd'
 
-const FormCheckbox = ({ label, name, rules = [] }) => {
+const FormCheckbox = ({ label, name, rules = [], dependencies = [] }) => {
   return (
-    <Form.Item name={name} rules={rules} valuePropName="checked">
+    <Form.Item
+      name={name}
+      rules={rules}
+      valuePropName="checked"
+      dependencies={dependencies}
+    >
       <Checkbox>{label}</Checkbox>
     </Form.Item>
   )
@@ -14,6 +19,7 @@ FormCheckbox.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   rules: PropTypes.array,
+  dependencies: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default FormCheckbox

--- a/src/Components/Forms/Field.js
+++ b/src/Components/Forms/Field.js
@@ -25,10 +25,17 @@ const Field = (props) => {
     rules = [],
     addonAfter = null,
     disabled = false,
+    dependencies = [],
   } = props
 
   return (
-    <Form.Item hasFeedback name={name} rules={rules} label={showLabel ? label : null}>
+    <Form.Item
+      hasFeedback
+      name={name}
+      rules={rules}
+      label={showLabel ? label : null}
+      dependencies={dependencies}
+    >
       <Input
         prefix={PrefixComponent && <PrefixComponent />}
         type={type}
@@ -51,6 +58,7 @@ Field.propTypes = {
   RenderField: PropTypes.func,
   addonAfter: PropTypes.string,
   disabled: PropTypes.bool,
+  dependencies: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default Field

--- a/src/Components/Forms/FileInput.js
+++ b/src/Components/Forms/FileInput.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 /**
  * Ant Design based file input. Only allows one file to be added to the form (per FileInput)
  */
-const FileInput = ({ label, name, rules = {} }) => {
+const FileInput = ({ label, name, rules = {}, dependencies = [] }) => {
   const [fileList, setFileList] = React.useState([])
 
   // Dummy request for Ant Design Upload component
@@ -48,6 +48,7 @@ const FileInput = ({ label, name, rules = {} }) => {
       rules={[...baseRules, ...rules]}
       label={label}
       valuePropName="file"
+      dependencies={dependencies}
     >
       <Upload
         name={name}
@@ -70,6 +71,7 @@ FileInput.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   rules: PropTypes.array,
+  dependencies: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default FileInput

--- a/src/Components/Forms/Form.js
+++ b/src/Components/Forms/Form.js
@@ -30,8 +30,10 @@ const FormFactory = ({
   loading = false,
   layout = 'horizontal',
 }) => {
+  const [formInstance] = Form.useForm()
   return (
     <Form
+      form={formInstance}
       name={name}
       onFinish={onSubmit}
       style={style}
@@ -41,7 +43,11 @@ const FormFactory = ({
       layout={layout}
     >
       {fields.map((field) => (
-        <Field {...field} key={`form-${name}-${field.name}`} />
+        <Field
+          {...field}
+          key={`form-${name}-${field.name}`}
+          formInstance={formInstance}
+        />
       ))}
       <Form.Item>
         <Button type="primary" htmlType="submit" disabled={loading}>

--- a/src/Components/Forms/InputNumber.js
+++ b/src/Components/Forms/InputNumber.js
@@ -8,10 +8,17 @@ const NumberInput = ({
   showLabel = false,
   placeholder = null,
   rules = [],
+  dependencies = [],
   ...props
 }) => {
   return (
-    <Form.Item hasFeedback name={name} rules={rules} label={showLabel ? label : null}>
+    <Form.Item
+      hasFeedback
+      name={name}
+      rules={rules}
+      label={showLabel ? label : null}
+      dependencies={dependencies}
+    >
       <InputNumber placeholder={placeholder || label} {...props} />
     </Form.Item>
   )
@@ -23,6 +30,7 @@ NumberInput.propTypes = {
   showLabel: PropTypes.bool,
   placeholder: PropTypes.string,
   rules: PropTypes.array,
+  dependencies: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default NumberInput

--- a/src/Components/Forms/Multiselect.js
+++ b/src/Components/Forms/Multiselect.js
@@ -11,6 +11,7 @@ const Multiselect = ({
   options = [],
   filterOption = false,
   optionLabel = '',
+  dependencies = [],
 }) => {
   const renderOption = (option, i) => {
     const label = typeof option === 'string' ? option : option[optionLabel]
@@ -25,7 +26,13 @@ const Multiselect = ({
   }
 
   return (
-    <Form.Item hasFeedback name={name} rules={rules} label={showLabel ? label : null}>
+    <Form.Item
+      hasFeedback
+      name={name}
+      rules={rules}
+      label={showLabel ? label : null}
+      dependencies={dependencies}
+    >
       <Select
         showSearch={filterOption}
         placeholder={placeholder}
@@ -49,6 +56,7 @@ Multiselect.propTypes = {
   ),
   filterOption: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   optionLabel: PropTypes.string,
+  dependencies: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default Multiselect

--- a/src/Components/Forms/RadioGroup.js
+++ b/src/Components/Forms/RadioGroup.js
@@ -8,9 +8,16 @@ const RadioGroup = ({
   showLabel = false,
   rules = [],
   options = [],
+  dependencies = [],
 }) => {
   return (
-    <Form.Item hasFeedback name={name} rules={rules} label={showLabel ? label : null}>
+    <Form.Item
+      hasFeedback
+      name={name}
+      rules={rules}
+      label={showLabel ? label : null}
+      dependencies={dependencies}
+    >
       <Radio.Group>
         {options.map((o, i) => (
           <Radio value={o.key} key={`${o.key}-opt-${i}`}>
@@ -36,6 +43,7 @@ RadioGroup.propTypes = {
   ),
   filterOption: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   optionLabel: PropTypes.string,
+  dependencies: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default RadioGroup

--- a/src/Components/Forms/SelectOrCreate.js
+++ b/src/Components/Forms/SelectOrCreate.js
@@ -13,14 +13,20 @@ import api from '../../api'
  * @param {string} props.url API Url that provides the options via GET and allows creation via POST. Must end with '/'
  * @param {object[]} props.createFields Array of fields for value creation, passed to FormFactory. See Forms/Form.js
  * @param {string} props.label Label for the field
+ * @param {string} props.buttonCreateLabel Label to use in submit button text
+ * @param {object} props.extraCreationValues Values to pass to POST body in addition to the form
+ * @param {object} props.extraQueryParams Values to pass to GET query to provider
+ * @param {*} props.formInstance Ant Design form instance.
  *  Other props are the same for any other field. See Forms/Field.js
  */
 const SelectOrCreate = ({
   url,
   createFields,
   label,
+  buttonCreateLabel = null,
   extraCreationValues = {},
   extraQueryParams = {},
+  formInstance = null,
   ...props
 }) => {
   const [data, setData] = React.useState([])
@@ -28,6 +34,14 @@ const SelectOrCreate = ({
   const [fetching, setFetching] = React.useState(false)
   const [loading, setLoading] = React.useState(false)
   const [visible, setVisible] = React.useState(false)
+  const [selected, setSelected] = React.useState(null)
+
+  const updateSelected = (newValue) => {
+    setSelected(newValue)
+    if (formInstance) {
+      formInstance.setFieldsValue({ [props.name]: newValue })
+    }
+  }
 
   // Fetch data from provider according to current search
   const fetchData = React.useCallback(
@@ -55,15 +69,21 @@ const SelectOrCreate = ({
     setLoading(true)
     const success = await api
       .post(url, { ...form, ...extraCreationValues })
-      .then(({ status }) => 200 <= status && status < 300)
+      .then(async (response) => {
+        const resp = await response.json()
+        return resp
+      })
       .catch(() => false)
     setLoading(false)
 
     if (success) {
-      fetchData('')
+      fetchData(form.name || form.names)
+      updateSelected({ value: success.id, label: success.name || success.names })
       setVisible(false)
     } else {
-      message.error(`There was an error creating the ${label}. Please try again`)
+      message.error(
+        `There was an error creating the ${buttonCreateLabel || label}. Please try again`,
+      )
     }
   }
 
@@ -77,12 +97,14 @@ const SelectOrCreate = ({
       >
         <Select
           labelInValue
+          value={selected}
+          onSelect={updateSelected}
           placeholder={`Select ${label}`}
           notFoundContent={fetching ? <Spin size="small" /> : null}
           filterOption={false}
-          onSearch={fetchData}
           options={data}
           showSearch
+          onSearch={fetchData}
           style={{ width: '100%' }}
         />
       </Form.Item>
@@ -94,7 +116,7 @@ const SelectOrCreate = ({
         </Button>
       </div>
       <Modal
-        title={`Create new ${label}`}
+        title={`Create new ${buttonCreateLabel || label}`}
         visible={visible}
         onCancel={() => setVisible(false)}
         footer={null}
@@ -103,7 +125,7 @@ const SelectOrCreate = ({
           name={`New${label}`}
           onSubmit={onSubmit}
           fields={createFields}
-          submitText={`Create ${label}`}
+          submitText={`Create ${buttonCreateLabel || label}`}
           initialValues={{ public: false }} // 'public' default value isn't set on component mount
           loading={loading}
         />
@@ -121,6 +143,8 @@ SelectOrCreate.propTypes = {
   rules: PropTypes.array,
   extraCreationValues: PropTypes.object,
   extraQueryParams: PropTypes.object,
+  buttonCreateLabel: PropTypes.string,
+  formInstance: PropTypes.any,
 }
 
 export default SelectOrCreate

--- a/src/Components/Forms/SelectOrCreate.js
+++ b/src/Components/Forms/SelectOrCreate.js
@@ -16,6 +16,7 @@ import api from '../../api'
  * @param {string} props.buttonCreateLabel Label to use in submit button text
  * @param {object} props.extraCreationValues Values to pass to POST body in addition to the form
  * @param {object} props.extraQueryParams Values to pass to GET query to provider
+ * @param {string[]=} props.dependencies Ant Design dependency array
  * @param {*} props.formInstance Ant Design form instance.
  *  Other props are the same for any other field. See Forms/Field.js
  */
@@ -27,6 +28,7 @@ const SelectOrCreate = ({
   extraCreationValues = {},
   extraQueryParams = {},
   formInstance = null,
+  dependencies = [],
   ...props
 }) => {
   const [data, setData] = React.useState([])
@@ -94,6 +96,7 @@ const SelectOrCreate = ({
         name={props.name}
         rules={props.rules}
         label={props.showLabel ? label : null}
+        dependencies={dependencies}
       >
         <Select
           labelInValue
@@ -145,6 +148,7 @@ SelectOrCreate.propTypes = {
   extraQueryParams: PropTypes.object,
   buttonCreateLabel: PropTypes.string,
   formInstance: PropTypes.any,
+  dependencies: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default SelectOrCreate

--- a/src/Components/Forms/SteppedForm.js
+++ b/src/Components/Forms/SteppedForm.js
@@ -63,7 +63,7 @@ const SteppedFormFactory = ({
       <div style={{ display: current === i ? 'block' : 'none' }} key={title}>
         <Card className="step-card">
           {fields.map((field) => (
-            <Field {...field} key={`form-${name}-${field.name}`} />
+            <Field {...field} key={`form-${name}-${field.name}`} formInstance={form} />
           ))}
           <Form.Item>
             <div className="step-buttons">

--- a/src/Components/Forms/TagInput.js
+++ b/src/Components/Forms/TagInput.js
@@ -2,9 +2,22 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Form, Select } from 'antd'
 
-const TagInput = ({ label, name, showLabel = false, placeholder = null, rules = [] }) => {
+const TagInput = ({
+  label,
+  name,
+  showLabel = false,
+  placeholder = null,
+  rules = [],
+  dependencies = [],
+}) => {
   return (
-    <Form.Item hasFeedback name={name} rules={rules} label={showLabel ? label : null}>
+    <Form.Item
+      hasFeedback
+      name={name}
+      rules={rules}
+      label={showLabel ? label : null}
+      dependencies={dependencies}
+    >
       <Select placeholder={placeholder || label} mode="tags" style={{ width: '100%' }} />
     </Form.Item>
   )
@@ -16,6 +29,7 @@ TagInput.propTypes = {
   showLabel: PropTypes.bool,
   placeholder: PropTypes.string,
   rules: PropTypes.array,
+  dependencies: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default TagInput

--- a/src/Components/Forms/TextArea.js
+++ b/src/Components/Forms/TextArea.js
@@ -2,9 +2,22 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Form, Input } from 'antd'
 
-const Field = ({ label, name, showLabel = false, placeholder = null, rules = [] }) => {
+const Field = ({
+  label,
+  name,
+  showLabel = false,
+  placeholder = null,
+  rules = [],
+  dependencies = [],
+}) => {
   return (
-    <Form.Item hasFeedback name={name} rules={rules} label={showLabel ? label : null}>
+    <Form.Item
+      hasFeedback
+      name={name}
+      rules={rules}
+      label={showLabel ? label : null}
+      dependencies={dependencies}
+    >
       <Input.TextArea placeholder={placeholder || label} />
     </Form.Item>
   )
@@ -16,6 +29,7 @@ Field.propTypes = {
   showLabel: PropTypes.bool,
   placeholder: PropTypes.string,
   rules: PropTypes.array,
+  dependencies: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default Field

--- a/src/Components/Upload/ExtraInfo.js
+++ b/src/Components/Upload/ExtraInfo.js
@@ -6,18 +6,20 @@ import PropTypes from 'prop-types'
 
 /** Form for assay metadata sumbission */
 const ExtraInfo = ({ onSubmit, extraInfoFields, loading = false, assayId }) => {
-  const steps = Object.entries(extraInfoFields).map(([type, fields]) => ({
-    title: type,
-    fields: fields.map((field) => ({
-      name: field,
-      label: field,
-      showLabel: true,
-      rules: [{ required: true }],
-      RenderField: SelectOrCreate,
-      extraCreationValues: { assays: [assayId] },
-      ...getFieldParams(type),
-    })),
-  }))
+  const steps = Object.entries(extraInfoFields)
+    .filter(([, fields]) => fields.length)
+    .map(([type, fields]) => ({
+      title: type,
+      fields: fields.map((field, i) => ({
+        name: `${type}-${i}`,
+        label: field,
+        showLabel: true,
+        rules: [{ required: true }],
+        RenderField: SelectOrCreate,
+        extraCreationValues: { assays: [assayId] },
+        ...getFieldParams(type),
+      })),
+    }))
 
   return (
     <SteppedFormFactory

--- a/src/Components/Upload/extraFieldParams.js
+++ b/src/Components/Upload/extraFieldParams.js
@@ -1,6 +1,17 @@
 import TagInput from '../Forms/TagInput'
 import TextArea from '../Forms/TextArea'
 
+const sbolUrisValidator = ({ getFieldValue }) => ({
+  validator(rule, value) {
+    if (!value) return Promise.resolve()
+    const names = getFieldValue('names')
+    if (names && value.length === names.length) {
+      return Promise.resolve()
+    }
+    return Promise.reject('The number of Sbol Uris must match the number of DNA names.')
+  },
+})
+
 /**
  * Maps required metadata fields
  * @param {'dna'|'inducer'|'signal'} type Field type
@@ -10,6 +21,7 @@ const getFieldParams = (type) => {
     case 'dna':
       return {
         url: 'dna/',
+        buttonCreateLabel: 'DNA',
         createFields: [
           {
             name: 'names',
@@ -27,25 +39,19 @@ const getFieldParams = (type) => {
             RenderField: TagInput,
             mode: 'tags',
             style: { width: '100%' },
+            rules: [sbolUrisValidator],
+            dependencies: ['names'],
           },
         ],
       }
     case 'inducer':
       return {
         url: 'inducer/',
+        buttonCreateLabel: 'Inducer',
         createFields: [
           {
             name: 'names',
             label: 'Names',
-            showLabel: true,
-            rules: [{ required: true }],
-            RenderField: TagInput,
-            mode: 'tags',
-            style: { width: '100%' },
-          },
-          {
-            name: 'concentrations',
-            label: 'Concentrations',
             showLabel: true,
             rules: [{ required: true }],
             RenderField: TagInput,
@@ -57,6 +63,7 @@ const getFieldParams = (type) => {
     case 'signal':
       return {
         url: 'signal/',
+        buttonCreateLabel: 'Signal',
         createFields: [
           {
             name: 'name',

--- a/src/Components/Upload/extraFieldParams.js
+++ b/src/Components/Upload/extraFieldParams.js
@@ -24,7 +24,6 @@ const getFieldParams = (type) => {
             name: 'sboluris',
             label: 'SBOL Uris',
             showLabel: true,
-            rules: [{ required: true }],
             RenderField: TagInput,
             mode: 'tags',
             style: { width: '100%' },

--- a/src/Components/Upload/uploadForm.js
+++ b/src/Components/Upload/uploadForm.js
@@ -40,7 +40,7 @@ const uploadSteps = [
             label: 'DOI',
             placeholder: 'DOI',
             showLabel: true,
-            rules: [{ required: true, type: 'url' }],
+            rules: [{ type: 'url' }],
           },
           {
             name: 'public',
@@ -80,11 +80,7 @@ const uploadSteps = [
         name: 'mock_title2',
         label: 'mock_title2',
         RenderField() {
-          return (
-            <Typography.Title level={3}>
-              Assays description and temperature
-            </Typography.Title>
-          )
+          return <Typography.Title level={3}>Assay</Typography.Title>
         },
       },
       {


### PR DESCRIPTION
- Browse: Forced refresh when deleting an item
- Upload metadata: Show only requested metadata (if there are no inducers, it doesn't show that step)
- Sbol uris and DOI no longer required
- SelectOrCreate: Now automatically selects created values
- DNA form: Sbol uris are validated such that, if there's any, the amount must match the number of names.